### PR TITLE
fix(ui)!: resolve scrollbar overlapping page content

### DIFF
--- a/src/app/App.module.scss
+++ b/src/app/App.module.scss
@@ -1,6 +1,5 @@
 .layout {
-    overflow: hidden;
-    min-height: 100vh;
-    width: 100vw;
-    background: #ffffff;
+  overflow: hidden;
+  min-height: 100vh;
+  background: #ffffff;
 }


### PR DESCRIPTION
Вместо `width: 100vw;` должно быть `width: 100%;`, но оно и так по умолчанию стоит. Иначе на компе скроллбар перекрывает часть контента. Но я не могу гарантировать, что после моего фикса ничего не сломалось) Всё нужно тщательно проверить...

<img width="1102" height="1328" alt="fix scrollbar overlay issue" src="https://github.com/user-attachments/assets/4a30ec3a-f484-4051-b4ad-8b4121c222d6" />